### PR TITLE
Fix a difference of behavior between GCC and Clang.

### DIFF
--- a/include/roboptim/core/util.hxx
+++ b/include/roboptim/core/util.hxx
@@ -62,7 +62,6 @@ namespace roboptim
     return o << "(" << p.first << ", " << p.second << ")";
   }
 
-  /// \brief Display an Eigen object with the appropriate IOFormat.
   template <typename T>
   std::ostream& operator<< (std::ostream& o, const Eigen::MatrixBase<T>& matrix)
   {

--- a/include/roboptim/core/visualization/gnuplot-commands.hh
+++ b/include/roboptim/core/visualization/gnuplot-commands.hh
@@ -19,6 +19,7 @@
 # define ROBOPTIM_CORE_VISUALIZATION_GNUPLOT_COMMANDS_HH
 # include <roboptim/core/sys.hh>
 # include <roboptim/core/debug.hh>
+# include <roboptim/core/util.hh>
 
 # include <string>
 # include <iostream>
@@ -59,13 +60,20 @@ namespace roboptim
       template <typename T>
       ROBOPTIM_DLLAPI Command comment (const T& content) throw ()
       {
-          // Note: we do not use boost::lexical_cast because the << operators
-          // need to be in the std:: or boost:: namespaces. As a result, if we
-          // try to add a comment with an Eigen matrix, it will not be printed
-          // in the RobOptim way. Thus, we stick to stringstream (for now).
-          std::stringstream ss;
-          ss << "# " << content;
-          return Command (ss.str ());
+        // Note: we do not use boost::lexical_cast because the << operators
+        // need to be in the std:: or boost:: namespaces. As a result, if we
+        // try to add a comment with an Eigen matrix, it will not be printed
+        // in the RobOptim way. Thus, we stick to stringstream (for now).
+        // Also, we use the "using" keyword to force the use of the RobOptim
+        // << operator when it is available (e.g. for Eigen matrices, pairs
+        // of values, etc.).
+        using roboptim::operator <<;
+        using std::operator <<;
+
+        std::stringstream ss;
+        ss << "# " << content;
+
+        return Command (ss.str ());
       }
 
       /// \brief Make a Gnuplot set command.


### PR DESCRIPTION
Argument-dependent name lookup seemed to behave differently when
using a code compiled with Clang (RobOptim << operator called) and
GCC (Eigen default << operator called).
