### PR TITLE
Allow SolverState to be modified in the callback.

### DIFF
--- a/include/roboptim/core/solver-state.hh
+++ b/include/roboptim/core/solver-state.hh
@@ -50,8 +50,9 @@ namespace roboptim
     ///   - vector (e.g. current x)
     ///   - integer (e.g. current iteration)
     ///   - string (e.g. warning message from the solver)
+    ///   - bool (e.g. whether to stop the optimization)
     typedef boost::variant<value_type, vector_t,
-                           int, std::string> stateParameterValues_t;
+                           int, std::string, bool> stateParameterValues_t;
 
     /// \brief Parameter description (for humans).
     std::string description;
@@ -113,6 +114,9 @@ namespace roboptim
     template <typename T>
     const T& getParameter (const std::string& key) const
       throw (std::out_of_range);
+
+    template <typename T>
+    T& getParameter (const std::string& key) throw (std::out_of_range);
     /// \}
 
 

--- a/include/roboptim/core/solver-state.hxx
+++ b/include/roboptim/core/solver-state.hxx
@@ -104,6 +104,17 @@ namespace roboptim
     return boost::get<T> (it->second.value);
   }
 
+  template <typename P>
+  template <typename T>
+  T&
+  SolverState<P>::getParameter (const std::string& key)
+    throw (std::out_of_range)
+  {
+    typename parameters_t::iterator it = parameters_.find (key);
+    if (it == parameters_.end ())
+      throw std::out_of_range ("key "+ key +" not found");
+    return boost::get<T> (it->second.value);
+  }
 
   template <typename P>
   std::ostream&

--- a/include/roboptim/core/solver.hh
+++ b/include/roboptim/core/solver.hh
@@ -92,10 +92,12 @@ namespace roboptim
     ///
     /// Callback parameters:
     /// \li problem is a (constant) reference to the problem
-    /// \li state is the current state of the optimization solver.
+    /// \li state is the current state of the optimization solver. It can be
+    ///     modified by the callback, and updated values can be used by the
+    ///     solver to determine what to do next.
     typedef boost::function
     <void (const problem_t& problem,
-           const solverState_t& state)> callback_t;
+           solverState_t& state)> callback_t;
 
 
     /// \brief Instantiate a solver from a problem.


### PR DESCRIPTION
Thus, one could implement a stop criterion in the callback, add a boolean in the parameter list, and the solver will read it once the callback has been called. This makes the callback/SolverState a two-way street.
