### PR TITLE
Export -DEIGEN_RUNTIME_NO_MALLOC flag for dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ IF (NOT LTDL_H_FOUND)
 ENDIF()
 #FIXME: check that libltdl.so is available instead of adding it blindly.
 PKG_CONFIG_APPEND_LIBS(ltdl)
-
+PKG_CONFIG_APPEND_CFLAGS (-DEIGEN_RUNTIME_NO_MALLOC)
 HEADER_INSTALL("${HEADERS}")
 
 ADD_SUBDIRECTORY(src)


### PR DESCRIPTION
  function.hh defines EIGEN_RUNTIME_NO_MALLOC variable before including
  Eigen/Core. If a dependency includes Eigen/Core before function.hh, function
  set_is_malloc_allowed turns out to be undefined.
  This pull request fixes this bug.
