### PR TITLE
Add support for constant functions with any input size.

### DIFF
--- a/include/roboptim/core/function/constant.hh
+++ b/include/roboptim/core/function/constant.hh
@@ -38,11 +38,23 @@ namespace roboptim
     ROBOPTIM_TWICE_DIFFERENTIABLE_FUNCTION_FWD_TYPEDEFS_
     (GenericLinearFunction<T>);
 
-    /// \brief Build an constant function.
+    /// \brief Build a constant function.
     ///
     /// \param offset constant function offset
     GenericConstantFunction (const vector_t& offset) throw ()
       : GenericLinearFunction<T> (static_cast<size_type> (offset.size ()),
+				  static_cast<size_type> (offset.size ()),
+				  "constant function"),
+	offset_ (offset)
+    {
+    }
+
+    /// \brief Build a constant function.
+    ///
+    /// \param input_size input size of the function
+    /// \param offset constant function offset
+    GenericConstantFunction (size_type input_size, const vector_t& offset) throw ()
+      : GenericLinearFunction<T> (input_size,
 				  static_cast<size_type> (offset.size ()),
 				  "constant function"),
 	offset_ (offset)


### PR DESCRIPTION
This is a feature I currently use to merge a constraint with its bounds, e.g. `g <= u` leads to `g' = g-u` with `g' <= 0`. The output size of `g` is known when using `offset`, but the input size may be anything (i.e. different than the output size).
