### PR TITLE
Fix for NumericQuadraticFunction with dynamic allocation checking

### DIFF
--- a/include/roboptim/core/numeric-quadratic-function.hxx
+++ b/include/roboptim/core/numeric-quadratic-function.hxx
@@ -117,8 +117,9 @@ namespace roboptim
   GenericNumericQuadraticFunction<T>::impl_gradient
   (gradient_ref gradient, const_argument_ref x, size_type) const
   {
-    gradient.noalias () = 2 * a_ * x;
-    gradient += b_;
+    buffer_.noalias () = 2 * a_ * x;
+    buffer_ += b_;
+    gradient = buffer_;
   }
 
   // A


### PR DESCRIPTION
Proposing a solution for the issue #90.

Basically using the Sparse way again. It works for both RowMajor and ColMajor modes.