### PR TITLE
Fix #88

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(PROJECT_URL "http://github.com/roboptim/roboptim-core")
 
 SET(HEADERS
   ${CMAKE_SOURCE_DIR}/include/roboptim/core.hh
+  ${CMAKE_SOURCE_DIR}/include/roboptim/core/alloc.hh
   ${CMAKE_SOURCE_DIR}/include/roboptim/core/cache.hh
   ${CMAKE_SOURCE_DIR}/include/roboptim/core/cache.hxx
   ${CMAKE_SOURCE_DIR}/include/roboptim/core/callback/multiplexer.hh

--- a/include/roboptim/core/alloc.hh
+++ b/include/roboptim/core/alloc.hh
@@ -1,0 +1,35 @@
+// Copyright (C) 2015 by Félix Darricau, AIST, CNRS, EPITA
+//
+// This file is part of the roboptim.
+//
+// roboptim is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// roboptim is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with roboptim.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef ROBOPTIM_CORE_ALLOC_HH
+# define ROBOPTIM_CORE_ALLOC_HH
+
+# include <roboptim/core/sys.hh>
+
+# define EIGEN_RUNTIME_NO_MALLOC
+# include <Eigen/Core>
+
+namespace roboptim
+{
+  ROBOPTIM_LOCAL
+  bool is_malloc_allowed_update(bool update, bool new_value);
+
+  ROBOPTIM_DLLAPI
+  bool set_is_malloc_allowed (bool allow);
+}
+
+#endif //! ROBOPTIM_CORE_ALLOC_HH

--- a/include/roboptim/core/decorator/finite-difference-gradient.hxx
+++ b/include/roboptim/core/decorator/finite-difference-gradient.hxx
@@ -403,7 +403,7 @@ namespace roboptim
      argument_ref xEps) const
     {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
       typedef Eigen::Triplet<double> triplet_t;
@@ -431,6 +431,10 @@ namespace roboptim
 	    }
 	}
       jacobian.setFromTriplets (coefficients.begin (), coefficients.end ());
+
+#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+      set_is_malloc_allowed (false);
+#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     }
 
     template <typename T>
@@ -668,7 +672,7 @@ namespace roboptim
      argument_ref xEps) const
     {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
       typedef Eigen::Triplet<double> triplet_t;

--- a/include/roboptim/core/differentiable-function.hh
+++ b/include/roboptim/core/differentiable-function.hh
@@ -150,11 +150,11 @@ namespace roboptim
       assert (argument.size () == this->inputSize ());
       assert (isValidJacobian (jacobian));
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (false);
+      set_is_malloc_allowed (false);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       this->impl_jacobian (jacobian, argument);
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       assert (isValidJacobian (jacobian));
     }
@@ -194,11 +194,11 @@ namespace roboptim
       assert (argument.size () == this->inputSize ());
       assert (isValidGradient (gradient));
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (false);
+      set_is_malloc_allowed (false);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       this->impl_gradient (gradient, argument, functionId);
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       assert (isValidGradient (gradient));
     }

--- a/include/roboptim/core/differentiable-function.hxx
+++ b/include/roboptim/core/differentiable-function.hxx
@@ -37,12 +37,9 @@ namespace roboptim
   (jacobian_ref jacobian, const_argument_ref argument)
     const
   {
-#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-    Eigen::internal::set_is_malloc_allowed (true);
-#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-
     typedef Eigen::Triplet<value_type> triplet_t;
     std::vector<triplet_t> coefficients;
+
     for (jacobian_t::Index i = 0; i < this->outputSize (); ++i)
       {
         gradient_t grad = gradient (argument, i);

--- a/include/roboptim/core/function.hh
+++ b/include/roboptim/core/function.hh
@@ -33,7 +33,8 @@
 # include <boost/preprocessor/punctuation/comma.hpp>
 
 # define EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
-# define EIGEN_RUNTIME_NO_MALLOC
+
+# include <roboptim/core/alloc.hh>
 # include <Eigen/Core>
 # include <Eigen/Dense>
 # include <Eigen/Sparse>
@@ -476,11 +477,11 @@ namespace roboptim
       assert (argument.size () == inputSize ());
       assert (isValidResult (result));
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (false);
+      set_is_malloc_allowed (false);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       this->impl_compute (result, argument);
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       assert (isValidResult (result));
     }

--- a/include/roboptim/core/n-times-derivable-function.hh
+++ b/include/roboptim/core/n-times-derivable-function.hh
@@ -213,10 +213,15 @@ namespace roboptim
 			size_type functionId = 0) const
     {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
       derivative_t derivative (derivativeSize ());
+
+#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+      set_is_malloc_allowed (false);
+#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+
       derivative.setZero ();
 
       this->derivative (derivative, argument[0], 1);
@@ -250,12 +255,17 @@ namespace roboptim
 		       size_type functionId = 0) const
     {
 # ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 # endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
       assert (functionId == 0);
 
       derivative_t derivative (derivativeSize ());
+
+#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+      set_is_malloc_allowed (false);
+#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+
       derivative.setZero ();
 
       this->derivative (derivative, argument[0], 2);

--- a/include/roboptim/core/numeric-quadratic-function.hxx
+++ b/include/roboptim/core/numeric-quadratic-function.hxx
@@ -77,10 +77,15 @@ namespace roboptim
   (jacobian_ref jacobian, const_argument_ref x) const
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-    Eigen::internal::set_is_malloc_allowed (true);
+    set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
     Eigen::MatrixXd j = 2 * x.transpose () * a_;
+
+#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+    set_is_malloc_allowed (false);
+#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
+
     for (size_type i = 0; i < this->inputSize (); ++i)
       j.coeffRef (0, i) += b_[i];
 

--- a/include/roboptim/core/sum-of-c1-squares.hxx
+++ b/include/roboptim/core/sum-of-c1-squares.hxx
@@ -62,13 +62,9 @@ namespace roboptim {
   void GenericSumOfC1Squares<T>::
   impl_compute(result_ref result, const_argument_ref x) const
   {
-#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-    Eigen::internal::set_is_malloc_allowed (true);
-#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-
     computeFunction (x);
     value_type sumSquares = 0;
-    for (size_t i = 0; i < value_.size(); i++) {
+    for (typename result_t::Index i = 0; i < value_.size(); i++) {
       value_type y = value_[i];
       sumSquares += y*y;
     }
@@ -80,10 +76,6 @@ namespace roboptim {
   impl_gradient(gradient_ref gradient, const_argument_ref x,
                 size_type ROBOPTIM_DEBUG_ONLY (row)) const
   {
-#ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-    Eigen::internal::set_is_malloc_allowed (true);
-#endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-
     assert (row == 0);
     computeFunction (x);
     gradient.setZero ();

--- a/include/roboptim/core/twice-differentiable-function.hh
+++ b/include/roboptim/core/twice-differentiable-function.hh
@@ -126,11 +126,11 @@ namespace roboptim
 		     "Evaluating hessian at point: " << argument);
       assert (isValidHessian (hessian));
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (false);
+      set_is_malloc_allowed (false);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       this->impl_hessian (hessian, argument, functionId);
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-      Eigen::internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
       assert (isValidHessian (hessian));

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ ADD_LIBRARY(roboptim-core SHARED
   ${HEADERS}
   debug.hh
   doc.hh
+  alloc.cc
   finite-difference-gradient.cc
   generic-solver.cc
   indent.cc

--- a/src/alloc.cc
+++ b/src/alloc.cc
@@ -1,0 +1,37 @@
+// Copyright (C) 2015 by Félix Darricau, AIST, CNRS, EPITA
+//
+// This file is part of the roboptim.
+//
+// roboptim is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// roboptim is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with roboptim.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "roboptim/core/alloc.hh"
+
+namespace roboptim
+{
+  bool is_malloc_allowed_update(bool update = false, bool new_value = false)
+  {
+    static bool value = true;
+    if (update)
+      value = new_value;
+    return value;
+  }
+
+  /// \brief Manage the calls to Eigen::set_is_malloc_allowed.
+  bool set_is_malloc_allowed (bool allow)
+  {
+    is_malloc_allowed_update(true, allow);
+
+    return Eigen::internal::set_is_malloc_allowed(allow);
+  }
+} // end of namespace roboptim.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,9 @@ ROBOPTIM_CORE_TEST(function-identity)
 ROBOPTIM_CORE_TEST(function-sin)
 ROBOPTIM_CORE_TEST(function-polynomial)
 
+# Sum Of C1 Squares.
+ROBOPTIM_CORE_TEST(sum-of-c1-squares)
+
 # Decorators.
 ROBOPTIM_CORE_TEST(decorator-cached-function)
 ROBOPTIM_CORE_TEST(decorator-finite-difference-gradient)

--- a/tests/detail-utility.cc
+++ b/tests/detail-utility.cc
@@ -58,9 +58,9 @@ namespace detail
       matrix_t m (2, 2);
       m << 1., 2., 3., 4.;
 
-      internal::set_is_malloc_allowed (false);
+      set_is_malloc_allowed (false);
       foo (m.row (1));
-      internal::set_is_malloc_allowed (true);
+      set_is_malloc_allowed (true);
 
       BOOST_CHECK (!m.row (0).isZero ());
       BOOST_CHECK (m.row (1).isZero ());

--- a/tests/function-pool.cc
+++ b/tests/function-pool.cc
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (function_pool, T, functionTypes_t)
                                   "Joint position pool");
 
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-    Eigen::internal::set_is_malloc_allowed (true);
+    set_is_malloc_allowed (true);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
   // Pre-allocate memory
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE (function_pool, T, functionTypes_t)
     fd_denseJac (pool->outputSize (), pool->inputSize ());
 
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
-  Eigen::internal::set_is_malloc_allowed (false);
+  set_is_malloc_allowed (false);
 #endif //! ROBOPTIM_DO_NOT_CHECK_ALLOCATION
 
   // Call the pool

--- a/tests/ref.cc
+++ b/tests/ref.cc
@@ -88,9 +88,9 @@ BOOST_AUTO_TEST_CASE (ref)
   F::jacobian_ref jac_ref (jac);
   F::const_argument_ref x_ref (map_x);
 
-  Eigen::internal::set_is_malloc_allowed (false);
+  set_is_malloc_allowed (false);
   f.jacobian (jac_ref, x_ref);
-  Eigen::internal::set_is_malloc_allowed (true);
+  set_is_malloc_allowed (true);
 
   (*output) << map_x << std::endl;
   (*output) << f << std::endl;

--- a/tests/sum-of-c1-squares.cc
+++ b/tests/sum-of-c1-squares.cc
@@ -1,0 +1,111 @@
+// Copyright (C) 2015 by Félix Darricau, AIST, CNRS, EPITA
+//
+// This file is part of the roboptim.
+//
+// roboptim is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// roboptim is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with roboptim.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "shared-tests/fixture.hh"
+
+#include <iostream>
+
+#include <roboptim/core/io.hh>
+#include <roboptim/core/sum-of-c1-squares.hh>
+
+using namespace roboptim;
+
+struct F : public DifferentiableFunction
+{
+  F () : DifferentiableFunction (4, 2,
+                                 "x₀ * x₃ * (x₀ + x₁ + x₂) + x₃, "
+                                 "x₀²")
+  {
+  }
+
+  void
+  impl_compute (result_ref result, const_argument_ref x) const
+  {
+    result (0) = x[0] * x[3] * (x[0] + x[1] + x[2]) + x[3];
+    result (1) = x[0] * x[0];
+  }
+
+  void
+  impl_gradient (gradient_ref grad, const_argument_ref x,
+                 size_type functionId) const
+  {
+    switch (functionId)
+    {
+      case 0:
+        {
+          grad[0] = x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]);
+          grad[1] = x[0] * x[3];
+          grad[2] = x[0] * x[3] + 1;
+          grad[3] = x[0] * (x[0] + x[1] + x[2]);
+        }
+        break;
+
+      case 1:
+        {
+          grad[0] = 2. * x[0];
+        }
+        break;
+
+      default:
+        abort ();
+    }
+  }
+};
+
+BOOST_FIXTURE_TEST_SUITE (core, TestSuiteConfiguration)
+
+BOOST_AUTO_TEST_CASE (sum_of_c1_squares)
+{
+  boost::shared_ptr<boost::test_tools::output_test_stream>
+    output = retrievePattern ("sum-of-c1-squares");
+
+  boost::shared_ptr<F> fptr =
+    boost::make_shared<F>();
+
+  SumOfC1Squares fSum(fptr, "null");
+
+  SumOfC1Squares::vector_t x (4);
+  x << 1., 2., 1., 2.;
+  SumOfC1Squares::gradient_t grad (fSum.gradientSize ());
+
+  (*output) << fSum << std::endl;
+
+  BOOST_CHECK (fSum.inputSize () == 4);
+
+  BOOST_CHECK (fSum.outputSize () == 1);
+
+  BOOST_CHECK (fSum.getName () == "null");
+
+  BOOST_CHECK (fSum.isValidResult (fSum (x)));
+
+  BOOST_CHECK (fSum(x)[0] == 101);
+
+  (*output) << fSum.gradient (x) << std::endl;
+
+  fSum.gradient (grad, x);
+  (*output) << grad << std::endl;
+
+  BOOST_CHECK (fSum.gradientSize () == 4);
+
+  BOOST_CHECK (fSum.isValidGradient (fSum.gradient (x)));
+
+
+  std::cout << output->str () << std::endl;
+  BOOST_CHECK (output->match_pattern ());
+}
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/sum-of-c1-squares.stdout
+++ b/tests/sum-of-c1-squares.stdout
@@ -1,0 +1,5 @@
+null (differentiable function)
+[4](204,40,60,80)
+[4](204,40,60,80)
+4
+1


### PR DESCRIPTION
IMHO, the wrapping function set_is_malloc_allowed is probably not optimally placed in the code as it is not supposed to be part of the detail namespace. It is totally possible to move it to a whole new file, or even to core.hh/function.hh (even thought that does not really sounds good to me).

The other commits are basically about removing no more needed calls to set_is_malloc_allowed, thanks to the use of Eigen::Ref and making sure each call setting the varaible to true is followed by one setting it to false as soon as the allocation part is done.