### PR TITLE
include GNUInstallDirs.cmake in top-level CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ SET(PROJECT_NAME roboptim-core)
 SET(PROJECT_DESCRIPTION "RobOptim Core")
 SET(PROJECT_URL "http://github.com/roboptim/roboptim-core")
 
+INCLUDE(cmake/GNUInstallDirs.cmake)
+
 # Use MathJax for Doxygen formulae
 SET(DOXYGEN_USE_MATHJAX "YES")
 


### PR DESCRIPTION
This is necessary for cmake to figure out CMAKE_INSTALL_LIBDIR
properly; otherwise it winds up using /usr/lib on distros where
it should use /usr/lib64.

NOTE: the location of the INCLUDE is significant. It has to be after `set(PROJECT_NAME`, or else docs get installed to `/usr/share/doc/Project`. It has to be *before* `SETUP_PROJECT()` for the fix to be effective.