### PR TITLE
Fix precompiled templates compilation for GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ branches:
   - coverity_scan
 script:
   - export CMAKE_ADDITIONAL_OPTIONS="-DSTORAGE_ORDER=${ROBOPTIM_STORAGE_ORDER:-ColMajor}"
+  - if [ "${ENABLE_CXX11}" == "1" ]; then export CMAKE_ADDITIONAL_OPTIONS="-DUSE_CXX11:BOOL=ON -DROBOPTIM_PRECOMPILE_DENSE_SPARSE:BOOL=ON ${CMAKE_ADDITIONAL_OPTIONS}"; fi
   - if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then ./.travis/run build; fi
 after_success:
   - ./.travis/run after_success
@@ -55,6 +56,14 @@ matrix:
     - os: linux
       dist: trusty
       compiler: clang
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: ENABLE_CXX11=1
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: ENABLE_CXX11=1
     - os: linux
       dist: precise
       compiler: gcc

--- a/include/roboptim/core/differentiable-function.hh
+++ b/include/roboptim/core/differentiable-function.hh
@@ -75,7 +75,7 @@ namespace roboptim
   /// The class provides a default value for the function id so that
   /// these functions do not have to explicitly set the function id.
   template <typename T>
-  class GenericDifferentiableFunction : public GenericFunction<T>
+  class ROBOPTIM_GCC_ETI_WORKAROUND GenericDifferentiableFunction : public GenericFunction<T>
   {
   public:
     ROBOPTIM_FUNCTION_FWD_TYPEDEFS_ (GenericFunction<T>);

--- a/include/roboptim/core/differentiable-function.hxx
+++ b/include/roboptim/core/differentiable-function.hxx
@@ -94,6 +94,15 @@ namespace roboptim
 
     return o << name << " (differentiable function)";
   }
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI GenericDifferentiableFunction<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI GenericDifferentiableFunction<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
+
 } // end of namespace roboptim
 
 #endif //! ROBOPTIM_CORE_DIFFERENTIABLE_FUNCTION

--- a/include/roboptim/core/function.hh
+++ b/include/roboptim/core/function.hh
@@ -179,13 +179,7 @@ namespace roboptim
   ///
   /// \tparam T Matrix type
   template <typename T>
-// Work around a probable bug in GCC, see #111
-# if defined(ROBOPTIM_PRECOMPILED_DENSE_SPARSE) && \
-     __GNUC__ >= 4 && not defined(__clang__)
-  class ROBOPTIM_CORE_DLLAPI GenericFunction
-# else
-  class GenericFunction
-# endif
+  class ROBOPTIM_GCC_ETI_WORKAROUND GenericFunction
   {
   public:
     ROBOPTIM_DEFINE_FLAG_TYPE();

--- a/include/roboptim/core/function.hh
+++ b/include/roboptim/core/function.hh
@@ -179,7 +179,7 @@ namespace roboptim
   ///
   /// \tparam T Matrix type
   template <typename T>
-  class GenericFunction
+  class ROBOPTIM_CORE_DLLAPI GenericFunction
   {
   public:
     ROBOPTIM_DEFINE_FLAG_TYPE();

--- a/include/roboptim/core/function.hh
+++ b/include/roboptim/core/function.hh
@@ -179,7 +179,13 @@ namespace roboptim
   ///
   /// \tparam T Matrix type
   template <typename T>
+// Work around a probable bug in GCC, see #111
+# if defined(ROBOPTIM_PRECOMPILED_DENSE_SPARSE) && \
+     __GNUC__ >= 4 && not defined(__clang__)
   class ROBOPTIM_CORE_DLLAPI GenericFunction
+# else
+  class GenericFunction
+# endif
   {
   public:
     ROBOPTIM_DEFINE_FLAG_TYPE();

--- a/include/roboptim/core/function/constant.hh
+++ b/include/roboptim/core/function/constant.hh
@@ -32,7 +32,7 @@ namespace roboptim
   /// \f[f(x) = offset\f]
   /// where \f$offset\f$ is set when the class is instantiated.
   template <typename T>
-  class ROBOPTIM_CORE_DLLAPI GenericConstantFunction
+  class GenericConstantFunction
   : public GenericLinearFunction<T>
   {
   public:
@@ -101,6 +101,14 @@ namespace roboptim
   /// \example constant-function.cc
 
   /// @}
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI GenericConstantFunction<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI GenericConstantFunction<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
 
 } // end of namespace roboptim
 

--- a/include/roboptim/core/function/cos.hh
+++ b/include/roboptim/core/function/cos.hh
@@ -28,7 +28,7 @@ namespace roboptim
 
   /// \brief Cos function.
   template <typename T>
-  class Cos : public GenericTwiceDifferentiableFunction<T>
+  class ROBOPTIM_GCC_ETI_WORKAROUND Cos : public GenericTwiceDifferentiableFunction<T>
   {
   public:
     ROBOPTIM_TWICE_DIFFERENTIABLE_FUNCTION_FWD_TYPEDEFS_
@@ -124,6 +124,14 @@ namespace roboptim
   /// \example function_cos.cc
 
   /// @}
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI Cos<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI Cos<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
 
 } // end of namespace roboptim
 

--- a/include/roboptim/core/function/identity.hh
+++ b/include/roboptim/core/function/identity.hh
@@ -31,7 +31,7 @@ namespace roboptim
   /// \f[f(x) = x + offset\f]
   /// where \f$A\f$ and \f$b\f$ are set when the class is instantiated.
   template <typename T>
-  class GenericIdentityFunction : public GenericLinearFunction<T>
+  class ROBOPTIM_GCC_ETI_WORKAROUND GenericIdentityFunction : public GenericLinearFunction<T>
   {
   public:
     ROBOPTIM_TWICE_DIFFERENTIABLE_FUNCTION_FWD_TYPEDEFS_
@@ -107,6 +107,14 @@ namespace roboptim
   /// \example identity-function.cc
 
   /// @}
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI GenericIdentityFunction<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI GenericIdentityFunction<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
 
 } // end of namespace roboptim
 

--- a/include/roboptim/core/function/polynomial.hxx
+++ b/include/roboptim/core/function/polynomial.hxx
@@ -163,6 +163,14 @@ namespace roboptim
     hessian.coeffRef (0, 0) = applyPolynomial (dDCoeffs_, x);
   }
 
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI Polynomial<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI Polynomial<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
+
 } // end of namespace roboptim
 
 #endif //! ROBOPTIM_CORE_FUNCTION_POLYNOMIAL_HXX

--- a/include/roboptim/core/function/sin.hh
+++ b/include/roboptim/core/function/sin.hh
@@ -28,7 +28,7 @@ namespace roboptim
 
   /// \brief Sin function.
   template <typename T>
-  class Sin : public GenericTwiceDifferentiableFunction<T>
+  class ROBOPTIM_GCC_ETI_WORKAROUND Sin : public GenericTwiceDifferentiableFunction<T>
   {
   public:
     ROBOPTIM_TWICE_DIFFERENTIABLE_FUNCTION_FWD_TYPEDEFS_
@@ -123,6 +123,14 @@ namespace roboptim
   /// \example sin.cc
 
   /// @}
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI Sin<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI Sin<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
 
 } // end of namespace roboptim
 

--- a/include/roboptim/core/linear-function.hxx
+++ b/include/roboptim/core/linear-function.hxx
@@ -47,6 +47,15 @@ namespace roboptim
     else
       return o << this->getName () << " (linear function)";
   }
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI GenericLinearFunction<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI GenericLinearFunction<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
+
 } // end of namespace roboptim
 
 #endif //! ROBOPTIM_CORE_LINEAR_FUNCTION_HXX

--- a/include/roboptim/core/portability.hh
+++ b/include/roboptim/core/portability.hh
@@ -87,4 +87,13 @@
 # define BOOST_NO_STD_LOCALE
 #endif
 
+// Work around for explicit template instantation in GCC, see #111 for
+// more details
+# if defined(ROBOPTIM_PRECOMPILED_DENSE_SPARSE) && \
+  __GNUC__ >= 4 && not defined(__clang__)
+# define ROBOPTIM_GCC_ETI_WORKAROUND ROBOPTIM_CORE_DLLAPI
+# else
+# define ROBOPTIM_GCC_ETI_WORKAROUND
+# endif
+
 #endif //! ROBOPTIM_CORE_PORTABILITY_HH

--- a/include/roboptim/core/problem.hh
+++ b/include/roboptim/core/problem.hh
@@ -76,13 +76,7 @@ namespace roboptim
   ///
   /// \tparam T matrix type
   template <typename T>
-// Work around a probable bug in GCC, see #111
-# if defined(ROBOPTIM_PRECOMPILED_DENSE_SPARSE) && \
-     __GNUC__ >= 4 && not defined(__clang__)
-  class ROBOPTIM_CORE_DLLAPI Problem
-#else
-  class Problem
-#endif
+  class ROBOPTIM_GCC_ETI_WORKAROUND Problem
   {
   public:
     /// \brief Function type.

--- a/include/roboptim/core/problem.hh
+++ b/include/roboptim/core/problem.hh
@@ -76,7 +76,13 @@ namespace roboptim
   ///
   /// \tparam T matrix type
   template <typename T>
+// Work around a probable bug in GCC, see #111
+# if defined(ROBOPTIM_PRECOMPILED_DENSE_SPARSE) && \
+     __GNUC__ >= 4 && not defined(__clang__)
   class ROBOPTIM_CORE_DLLAPI Problem
+#else
+  class Problem
+#endif
   {
   public:
     /// \brief Function type.

--- a/include/roboptim/core/problem.hh
+++ b/include/roboptim/core/problem.hh
@@ -76,7 +76,7 @@ namespace roboptim
   ///
   /// \tparam T matrix type
   template <typename T>
-  class Problem
+  class ROBOPTIM_CORE_DLLAPI Problem
   {
   public:
     /// \brief Function type.

--- a/include/roboptim/core/problem.hxx
+++ b/include/roboptim/core/problem.hxx
@@ -729,8 +729,10 @@ namespace roboptim
 
 // Explicit template instantiations for dense and sparse matrices.
 # ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
   extern template class ROBOPTIM_CORE_DLLAPI Problem<EigenMatrixDense>;
   extern template class ROBOPTIM_CORE_DLLAPI Problem<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
 # endif //! ROBOPTIM_PRECOMPILED_DENSE_SPARSE
 
 } // end of namespace roboptim

--- a/include/roboptim/core/quadratic-function.hxx
+++ b/include/roboptim/core/quadratic-function.hxx
@@ -38,6 +38,15 @@ namespace roboptim
     else
       return o << this->getName () << " (quadratic function)";
   }
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI GenericQuadraticFunction<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI GenericQuadraticFunction<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
+
 } // end of namespace roboptim
 
 #endif //! ROBOPTIM_CORE_QUADRATIC_FUNCTION_HXX

--- a/include/roboptim/core/result-analyzer.hh
+++ b/include/roboptim/core/result-analyzer.hh
@@ -32,7 +32,7 @@ namespace roboptim
   ///
   /// \tparam T matrix type (dense or sparse).
   template <typename T>
-  class ResultAnalyzer
+  class ROBOPTIM_CORE_DLLAPI ResultAnalyzer
   {
   public:
     typedef GenericFunctionTraits<T>              functionTraits_t;

--- a/include/roboptim/core/result-analyzer.hh
+++ b/include/roboptim/core/result-analyzer.hh
@@ -32,7 +32,7 @@ namespace roboptim
   ///
   /// \tparam T matrix type (dense or sparse).
   template <typename T>
-  class ROBOPTIM_CORE_DLLAPI ResultAnalyzer
+  class ROBOPTIM_GCC_ETI_WORKAROUND ResultAnalyzer
   {
   public:
     typedef GenericFunctionTraits<T>              functionTraits_t;

--- a/include/roboptim/core/result-analyzer.hxx
+++ b/include/roboptim/core/result-analyzer.hxx
@@ -488,10 +488,12 @@ namespace roboptim
 
 // Explicit template instantiations for dense and sparse matrices.
 # ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
   extern template class ROBOPTIM_CORE_DLLAPI
     ResultAnalyzer<EigenMatrixDense>;
   extern template class ROBOPTIM_CORE_DLLAPI
     ResultAnalyzer<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
 # endif //! ROBOPTIM_PRECOMPILED_DENSE_SPARSE
 
 } // end of namespace roboptim

--- a/include/roboptim/core/scaling-helper.hxx
+++ b/include/roboptim/core/scaling-helper.hxx
@@ -163,10 +163,12 @@ namespace roboptim
 
 // Explicit template instantiations for dense and sparse matrices.
 # ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
   extern template class ROBOPTIM_CORE_DLLAPI
     ScalingHelper<EigenMatrixDense>;
   extern template class ROBOPTIM_CORE_DLLAPI
     ScalingHelper<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
 # endif //! ROBOPTIM_PRECOMPILED_DENSE_SPARSE
 
 } // end of namespace roboptim

--- a/include/roboptim/core/twice-differentiable-function.hxx
+++ b/include/roboptim/core/twice-differentiable-function.hxx
@@ -52,6 +52,15 @@ namespace roboptim
 
     return o << name << " (twice differentiable function)";
   }
+
+// Explicit template instantiations for dense and sparse matrices.
+# ifdef ROBOPTIM_PRECOMPILED_DENSE_SPARSE
+  ROBOPTIM_ALLOW_ATTRIBUTES_ON
+  extern template class ROBOPTIM_CORE_DLLAPI GenericTwiceDifferentiableFunction<EigenMatrixDense>;
+  extern template class ROBOPTIM_CORE_DLLAPI GenericTwiceDifferentiableFunction<EigenMatrixSparse>;
+  ROBOPTIM_ALLOW_ATTRIBUTES_OFF
+# endif
+
 } // end of namespace roboptim
 
 #endif //! ROBOPTIM_CORE_TWICE_DIFFERENTIABLE_FUNCTION_HXX

--- a/src/roboptim-core-precompile.cc
+++ b/src/roboptim-core-precompile.cc
@@ -29,6 +29,11 @@
 #include <roboptim/core/optimization-logger.hh>
 #include <roboptim/core/callback/multiplexer.hh>
 #include <roboptim/core/callback/wrapper.hh>
+#include <roboptim/core/function/constant.hh>
+#include <roboptim/core/function/cos.hh>
+#include <roboptim/core/function/identity.hh>
+#include <roboptim/core/function/polynomial.hh>
+#include <roboptim/core/function/sin.hh>
 
 namespace roboptim
 {
@@ -37,6 +42,18 @@ namespace roboptim
 
   template class GenericFunction<EigenMatrixDense>;
   template class GenericFunction<EigenMatrixSparse>;
+
+  template class GenericDifferentiableFunction<EigenMatrixDense>;
+  template class GenericDifferentiableFunction<EigenMatrixSparse>;
+
+  template class GenericTwiceDifferentiableFunction<EigenMatrixDense>;
+  template class GenericTwiceDifferentiableFunction<EigenMatrixSparse>;
+
+  template class GenericLinearFunction<EigenMatrixDense>;
+  template class GenericLinearFunction<EigenMatrixSparse>;
+
+  template class GenericQuadraticFunction<EigenMatrixDense>;
+  template class GenericQuadraticFunction<EigenMatrixSparse>;
 
   template class GenericNumericQuadraticFunction<EigenMatrixDense>;
   template class GenericNumericQuadraticFunction<EigenMatrixSparse>;
@@ -70,6 +87,21 @@ namespace roboptim
 
   template class OptimizationLogger<Solver<EigenMatrixDense> >;
   template class OptimizationLogger<Solver<EigenMatrixSparse> >;
+
+  template class GenericConstantFunction<EigenMatrixDense>;
+  template class GenericConstantFunction<EigenMatrixSparse>;
+
+  template class Cos<EigenMatrixDense>;
+  template class Cos<EigenMatrixSparse>;
+
+  template class GenericIdentityFunction<EigenMatrixDense>;
+  template class GenericIdentityFunction<EigenMatrixSparse>;
+
+  template class Polynomial<EigenMatrixDense>;
+  template class Polynomial<EigenMatrixSparse>;
+
+  template class Sin<EigenMatrixDense>;
+  template class Sin<EigenMatrixSparse>;
 
   namespace callback
   {


### PR DESCRIPTION
- Add some necessary ROBOPTIM_ALLOW_ATTRIBUTES_ON/OFF
- Work-around for GCC bugs 40068/50044

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=40068
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=50044

The problems is related to visibility default being hidden (which is what the warning discarded by `ROBOPTIM_ALLOW_ATTRIBUTES_ON` is telling) resulting in the visibility value being discarded.

I am not sure this is the best solution and especially, I am not sure this would be accepted by MSVC since I seem to recall that trying to dllexport templated classes is forbidden by the compiler.

An alternative would be to change (i.e. remove) the visibility option when compiling with `ROBOPTIM_PRECOMPILE_DENSE_SPARSE`