### PR TITLE
replace include of iosfwd by string

### DIFF
--- a/include/roboptim/core/fwd.hh
+++ b/include/roboptim/core/fwd.hh
@@ -19,7 +19,7 @@
 # define ROBOPTIM_CORE_FWD_HH
 
 // TODO: remove as soon as the typeString() problem is solved
-# include <iosfwd>
+# include <string>
 
 # include <roboptim/core/portability.hh>
 


### PR DESCRIPTION
iosfwd does not forward declare string, and there is no way to forward declare string properly: http://www.gotw.ca/gotw/034.htm